### PR TITLE
Add MPI Flavors (Linux/macOS)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,16 +8,40 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_mpimpich:
+        CONFIG: linux_64_mpimpich
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_:
-        CONFIG: linux_aarch64_
+      linux_64_mpinompi:
+        CONFIG: linux_64_mpinompi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_:
-        CONFIG: linux_ppc64le_
+      linux_64_mpiopenmpi:
+        CONFIG: linux_64_mpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_mpimpich:
+        CONFIG: linux_aarch64_mpimpich
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_mpinompi:
+        CONFIG: linux_aarch64_mpinompi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_mpiopenmpi:
+        CONFIG: linux_aarch64_mpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_mpimpich:
+        CONFIG: linux_ppc64le_mpimpich
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_mpinompi:
+        CONFIG: linux_ppc64le_mpinompi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_mpiopenmpi:
+        CONFIG: linux_ppc64le_mpiopenmpi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,11 +8,23 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_mpimpich:
+        CONFIG: osx_64_mpimpich
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_:
-        CONFIG: osx_arm64_
+      osx_64_mpinompi:
+        CONFIG: osx_64_mpinompi
+        UPLOAD_PACKAGES: 'True'
+      osx_64_mpiopenmpi:
+        CONFIG: osx_64_mpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpimpich:
+        CONFIG: osx_arm64_mpimpich
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpinompi:
+        CONFIG: osx_arm64_mpinompi
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpiopenmpi:
+        CONFIG: osx_arm64_mpiopenmpi
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_64_mpimpich.yaml
+++ b/.ci_support/linux_64_mpimpich.yaml
@@ -1,0 +1,27 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_64_mpinompi.yaml
+++ b/.ci_support/linux_64_mpinompi.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '12'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -14,8 +14,14 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '4'
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_mpiopenmpi.yaml
+++ b/.ci_support/linux_64_mpiopenmpi.yaml
@@ -1,0 +1,27 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_mpimpich.yaml
+++ b/.ci_support/linux_aarch64_mpimpich.yaml
@@ -18,6 +18,12 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_mpinompi.yaml
+++ b/.ci_support/linux_aarch64_mpinompi.yaml
@@ -1,0 +1,31 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_mpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpi.yaml
@@ -1,0 +1,31 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_mpimpich.yaml
+++ b/.ci_support/linux_ppc64le_mpimpich.yaml
@@ -1,0 +1,27 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_mpinompi.yaml
+++ b/.ci_support/linux_ppc64le_mpinompi.yaml
@@ -1,0 +1,27 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_mpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpi.yaml
@@ -1,0 +1,27 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_mpimpich.yaml
+++ b/.ci_support/osx_64_mpimpich.yaml
@@ -1,0 +1,29 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '16'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_mpinompi.yaml
+++ b/.ci_support/osx_64_mpinompi.yaml
@@ -1,21 +1,29 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
-cdt_name:
-- cos6
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '4'
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_mpiopenmpi.yaml
+++ b/.ci_support/osx_64_mpiopenmpi.yaml
@@ -16,6 +16,12 @@ llvm_openmp:
 - '16'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_mpimpich.yaml
+++ b/.ci_support/osx_arm64_mpimpich.yaml
@@ -16,6 +16,12 @@ llvm_openmp:
 - '16'
 macos_machine:
 - arm64-apple-darwin20.0.0
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '4'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_mpinompi.yaml
+++ b/.ci_support/osx_arm64_mpinompi.yaml
@@ -1,0 +1,29 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '16'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+llvm_openmp:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_mpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpi.yaml
@@ -1,0 +1,29 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '16'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+llvm_openmp:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '4'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,8 +6,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
-libxml2:
-- '2.11'
 mpi:
 - nompi
 mpich:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -8,5 +8,11 @@ cxx_compiler:
 - vs2019
 libxml2:
 - '2.11'
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '4'
 target_platform:
 - win-64

--- a/README.md
+++ b/README.md
@@ -37,38 +37,108 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_mpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64</td>
+              <td>linux_64_mpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpinompi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le</td>
+              <td>linux_64_mpiopenmpi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>linux_aarch64_mpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64</td>
+              <td>linux_aarch64_mpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_mpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_mpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_mpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_mpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,6 +10,12 @@ fi
 if [[ ${target_platform} =~ osx.* ]]; then
     export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 fi
+# MPI variants
+if [[ ${mpi} == "nompi" ]]; then
+    export USE_MPI=OFF
+else
+    export USE_MPI=ON
+fi
 
 # configure
 cmake \
@@ -28,7 +34,7 @@ cmake \
     -DAMReX_HDF5=OFF                  \
     -DAMReX_HYPRE=OFF                 \
     -DAMReX_IPO=OFF                   \
-    -DAMReX_MPI=OFF                   \
+    -DAMReX_MPI=${USE_MPI}            \
     -DAMReX_MPI_THREAD_MULTIPLE=OFF   \
     -DAMReX_OMP=ON                    \
     -DAMReX_PARTICLES=ON              \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,6 +28,13 @@ if [[ "$mpi" == "openmpi" ]]; then
     export OMPI_MCA_rmaps_base_oversubscribe=yes
     export OMPI_MCA_btl_vader_single_copy_mechanism=none
 fi
+# CMake cannot find OpenMPI when cross-compiling for arm64 on macOS
+if [[ "$mpi" == "openmpi" &&
+      ${target_platform} =~ osx.* &&
+      "${CONDA_BUILD_CROSS_COMPILATION:-}" == "1" ]]; then
+
+    export OPAL_PREFIX=${PREFIX}
+fi
 
 # configure
 cmake \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,6 +16,18 @@ if [[ ${mpi} == "nompi" ]]; then
 else
     export USE_MPI=ON
 fi
+#   see https://github.com/conda-forge/hdf5-feedstock/blob/master/recipe/mpiexec.sh
+if [[ "$mpi" == "mpich" ]]; then
+    export HYDRA_LAUNCHER=fork
+    #export HYDRA_LAUNCHER=ssh
+fi
+if [[ "$mpi" == "openmpi" ]]; then
+    export OMPI_MCA_btl=self,tcp
+    export OMPI_MCA_plm=isolated
+    #export OMPI_MCA_plm=ssh
+    export OMPI_MCA_rmaps_base_oversubscribe=yes
+    export OMPI_MCA_btl_vader_single_copy_mechanism=none
+fi
 
 # configure
 cmake \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+mpi:
+  - nompi
+  - mpich  # [unix]
+  - openmpi  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,14 @@
 {% set name = "amrex" %}
 {% set version = "23.10" %}
+{% set build = 3 %}
+
+# ensure mpi is defined (needed for conda-smithy recipe-lint)
+{% set mpi = mpi or 'nompi' %}
+
+# prioritize nompi variant via build number
+{% if mpi == 'nompi' %}
+{% set build = build + 100 %}
+{% endif %}
 
 package:
   name: {{ name|lower }}
@@ -15,13 +24,29 @@ source:
     - 3599.patch
 
 build:
-  number: 2
+  number: {{ build }}
+
+  # add build string so packages can depend on
+  # mpi or nompi variants
+  # dependencies:
+  # `pkg * mpi_mpich_*` for mpich
+  # `pkg * mpi_*` for any mpi
+  # `pkg * nompi_*` for no mpi
+  {% if mpi == 'nompi' %}
+  {% set mpi_prefix = "nompi" %}
+  {% else %}
+  {% set mpi_prefix = "mpi_" + mpi %}
+  {% endif %}
+  string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
+
+  run_exports:
+    # strict runtime dependency on build-time MPI flavor
+    - {{ name }} * {{ mpi_prefix }}_*
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - ccache        # [unix]
     - clang         # [win]
     - cmake
     - lld           # [win]
@@ -32,6 +57,10 @@ requirements:
     - libgomp       # [linux]
     - llvm-openmp   # [osx or win]
     - pkgconfig
+  host:
+    - {{ mpi }}  # [mpi != 'nompi']
+  run:
+    - {{ mpi }}  # [mpi != 'nompi']
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,8 +53,6 @@ requirements:
     - clang         # [win]
     - cmake
     - lld           # [win]
-    # TODO: add libxml2 dep in lld-feedstock
-    - libxml2       # [win]
     - make          # [unix]
     - ninja         # [win]
     - libgomp       # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,10 @@ requirements:
     - libgomp       # [linux]
     - llvm-openmp   # [osx or win]
     - pkgconfig
+    # In OpenMPI, the compiler wrappers are binaries and the wrappers in build
+    # can use host libraries by adding OPAL_PREFIX and in mpich, compiler
+    # wrappers are bash scripts and wrappers in build can't use host libraries.
+    - openmpi  # [mpi == "openmpi" and (build_platform != target_platform)]
   host:
     - {{ mpi }}  # [mpi != 'nompi']
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,9 @@ build:
   run_exports:
     # strict runtime dependency on build-time MPI flavor
     - {{ name }} * {{ mpi_prefix }}_*
+    # Releases are not (yet) compatible:
+    # There is no ABI compatibility check or guarantee between AMReX releases.
+    - amrex {{ version }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,6 +61,7 @@ requirements:
     - {{ mpi }}  # [mpi != 'nompi']
   run:
     - {{ mpi }}  # [mpi != 'nompi']
+    - libcxx  # [osx]
 
 test:
   commands:


### PR DESCRIPTION
Default is `nompi`.

Reference:
- https://conda-forge.org/docs/maintainer/knowledge_base.html#building-mpi-variants

Allows users to install the following:

- `conda install amrex` default, nompi variant
- `conda install amrex=*=mpi*` any mpi-compatible implementation
- `conda install amrex=*=mpi_mpich*` pick mpich variant. Same result as `conda install mpich amrex=*=mpi*`
- `conda install amrex=23.10=nompi*` explicitly forbid MPI. Usually not necessary, as the build number offset causes `nompi` to be preferred unless MPI is explicitly requested.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
