### PR TITLE
Fix: AMReXBuildInfo on Windows

### DIFF
--- a/recipe/3599.patch
+++ b/recipe/3599.patch
@@ -1,4 +1,4 @@
-From a553e39ef6b93c2e9a72de6b02b98ea21a4e56e3 Mon Sep 17 00:00:00 2001
+From 83b47ec804d2d49ed9d78c6dd80f84d3429af1ed Mon Sep 17 00:00:00 2001
 From: Axel Huebl <axel.huebl@plasma.ninja>
 Date: Wed, 18 Oct 2023 09:58:37 -0700
 Subject: [PATCH] Install Move Tools to `shared/amrex`
@@ -11,16 +11,16 @@ This moves its content in both the build directory and the
 install destination to `share/amrex/` and
 `<CMakePkgRoot>/AMReXCMakeModules/`, respectively.
 ---
- Tools/CMake/AMReXBuildInfo.cmake      | 29 +++++++++++++++++++------
- Tools/CMake/AMReXInstallHelpers.cmake | 31 ++++++++++++++++++---------
- Tools/CMake/AMReXTypecheck.cmake      |  8 +++++--
- 3 files changed, 49 insertions(+), 19 deletions(-)
+ Tools/CMake/AMReXBuildInfo.cmake      | 36 +++++++++++++++++++++------
+ Tools/CMake/AMReXInstallHelpers.cmake | 31 +++++++++++++++--------
+ Tools/CMake/AMReXTypecheck.cmake      |  8 ++++--
+ 3 files changed, 56 insertions(+), 19 deletions(-)
 
 diff --git a/Tools/CMake/AMReXBuildInfo.cmake b/Tools/CMake/AMReXBuildInfo.cmake
-index 36c7005787..77a90e4fd3 100644
+index 36c7005787..fe11c69a3e 100644
 --- a/Tools/CMake/AMReXBuildInfo.cmake
 +++ b/Tools/CMake/AMReXBuildInfo.cmake
-@@ -38,15 +38,30 @@ include(AMReXTargetHelpers)
+@@ -38,15 +38,37 @@ include(AMReXTargetHelpers)
  #
  # Set paths
  #
@@ -30,8 +30,15 @@ index 36c7005787..77a90e4fd3 100644
 -set( AMREX_BUILDINFO_IFILE ${CMAKE_CURRENT_LIST_DIR}/AMReX_buildInfo.cpp.in
 +if (AMReX_FOUND)
 +   # AMReX is pre-installed and used as a library
-+   string(REPLACE "/lib/cmake/AMReX/AMReXCMakeModules" "" AMREX_TOP_DIR_DEFAULT
-+          ${CMAKE_CURRENT_LIST_DIR})
++   if (WIN32)  # see AMReXInstallHelpers.cmake
++       string(REPLACE "/cmake/AMReXCMakeModules" ""
++              AMREX_TOP_DIR_DEFAULT
++              ${CMAKE_CURRENT_LIST_DIR})
++   else ()
++       string(REPLACE "/lib/cmake/AMReX/AMReXCMakeModules" ""
++              AMREX_TOP_DIR_DEFAULT
++              ${CMAKE_CURRENT_LIST_DIR})
++   endif ()
 +else ()
 +   # this is a superbuild
 +   string(REPLACE "/Tools/CMake" "" AMREX_TOP_DIR_DEFAULT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,12 @@ source:
   sha256: e76e4787735c06ae747eaf57a682b12fed297ef2d5c7727051e20d34e4e79ce3
   patches:
     # Install CMake Scripts from Tools/CMake/ to <CMakePkgRoot>/Modules/
-    # https://github.com/AMReX-Codes/amrex/pull/3599
+    #   https://github.com/AMReX-Codes/amrex/pull/3599
+    #   https://github.com/AMReX-Codes/amrex/pull/3606
     - 3599.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Generalize the install path of CMake helper scripts to also work well on Windows.

X-ref: https://github.com/AMReX-Codes/amrex/pull/3606

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
