### PR TITLE
[Patch] OpenMP Linkage Windows

### DIFF
--- a/recipe/3796.patch
+++ b/recipe/3796.patch
@@ -1,0 +1,50 @@
+From a2d224f28cd76b29a22b0b291c7e07aac2e64ad7 Mon Sep 17 00:00:00 2001
+From: Axel Huebl <axel.huebl@plasma.ninja>
+Date: Sun, 10 Mar 2024 22:40:16 -0700
+Subject: [PATCH] `omp_locks`: C Array
+
+Use a plain C array over a `std::array` for `omp_locks`.
+Primarily because this causes linker issues on MSVC, secondarily
+because `omp_locks` might violate on some implementations the
+type requirements of `std::array` (MoveConstructible and
+MoveAssignable type `T`).
+https://en.cppreference.com/w/cpp/container/array
+---
+ Src/Base/AMReX_OpenMP.H   | 3 +--
+ Src/Base/AMReX_OpenMP.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/Src/Base/AMReX_OpenMP.H b/Src/Base/AMReX_OpenMP.H
+index 2b53ea8c6e..e31a917145 100644
+--- a/Src/Base/AMReX_OpenMP.H
++++ b/Src/Base/AMReX_OpenMP.H
+@@ -5,7 +5,6 @@
+ #ifdef AMREX_USE_OMP
+ #include <AMReX_Extension.H>
+ #include <omp.h>
+-#include <array>
+ 
+ namespace amrex::OpenMP {
+ 
+@@ -19,7 +18,7 @@ namespace amrex::OpenMP {
+     void Finalize ();
+ 
+     static constexpr int nlocks = 128;
+-    extern AMREX_EXPORT std::array<omp_lock_t,nlocks> omp_locks;
++    extern AMREX_EXPORT omp_lock_t omp_locks[nlocks];
+ }
+ 
+ #else // AMREX_USE_OMP
+diff --git a/Src/Base/AMReX_OpenMP.cpp b/Src/Base/AMReX_OpenMP.cpp
+index 15bb124607..8d7cb13824 100644
+--- a/Src/Base/AMReX_OpenMP.cpp
++++ b/Src/Base/AMReX_OpenMP.cpp
+@@ -135,7 +135,7 @@ namespace amrex
+ #ifdef AMREX_USE_OMP
+ namespace amrex::OpenMP
+ {
+-    std::array<omp_lock_t,nlocks> omp_locks;
++    omp_lock_t omp_locks[nlocks];
+ 
+     namespace {
+         unsigned int initialized = 0;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "amrex" %}
 {% set version = "24.03" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
@@ -17,6 +17,10 @@ package:
 source:
   url: https://github.com/AMReX-Codes/amrex/archive/refs/tags/{{ version }}.tar.gz
   sha256: 7e87197e8700d52d1ce009faa8df7e1a00027df799a1223c77a84bb5f96830e0
+  patches:
+    # Linker Error for Windows OpenMP build
+    # https://github.com/AMReX-Codes/amrex/pull/3796
+    - 3796.patch
 
 build:
   number: {{ build }}


### PR DESCRIPTION
Patch in
  https://github.com/AMReX-Codes/amrex/pull/3796
for `omp_locks` on Windows builds.

The issue is only seen in Windows downstream builds of WarpX and ImpactX.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
