### PR TITLE
AMReX: SP Build

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,40 +8,76 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_mpimpich:
-        CONFIG: linux_64_mpimpich
+      linux_64_amrex_precisiondpmpimpich:
+        CONFIG: linux_64_amrex_precisiondpmpimpich
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_mpinompi:
-        CONFIG: linux_64_mpinompi
+      linux_64_amrex_precisiondpmpinompi:
+        CONFIG: linux_64_amrex_precisiondpmpinompi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_mpiopenmpi:
-        CONFIG: linux_64_mpiopenmpi
+      linux_64_amrex_precisiondpmpiopenmpi:
+        CONFIG: linux_64_amrex_precisiondpmpiopenmpi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_mpimpich:
-        CONFIG: linux_aarch64_mpimpich
+      linux_64_amrex_precisionspmpimpich:
+        CONFIG: linux_64_amrex_precisionspmpimpich
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_mpinompi:
-        CONFIG: linux_aarch64_mpinompi
+      linux_64_amrex_precisionspmpinompi:
+        CONFIG: linux_64_amrex_precisionspmpinompi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_mpiopenmpi:
-        CONFIG: linux_aarch64_mpiopenmpi
+      linux_64_amrex_precisionspmpiopenmpi:
+        CONFIG: linux_64_amrex_precisionspmpiopenmpi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_ppc64le_mpimpich:
-        CONFIG: linux_ppc64le_mpimpich
+      linux_aarch64_amrex_precisiondpmpimpich:
+        CONFIG: linux_aarch64_amrex_precisiondpmpimpich
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_ppc64le_mpinompi:
-        CONFIG: linux_ppc64le_mpinompi
+      linux_aarch64_amrex_precisiondpmpinompi:
+        CONFIG: linux_aarch64_amrex_precisiondpmpinompi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_ppc64le_mpiopenmpi:
-        CONFIG: linux_ppc64le_mpiopenmpi
+      linux_aarch64_amrex_precisiondpmpiopenmpi:
+        CONFIG: linux_aarch64_amrex_precisiondpmpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_amrex_precisionspmpimpich:
+        CONFIG: linux_aarch64_amrex_precisionspmpimpich
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_amrex_precisionspmpinompi:
+        CONFIG: linux_aarch64_amrex_precisionspmpinompi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_amrex_precisionspmpiopenmpi:
+        CONFIG: linux_aarch64_amrex_precisionspmpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_amrex_precisiondpmpimpich:
+        CONFIG: linux_ppc64le_amrex_precisiondpmpimpich
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_amrex_precisiondpmpinompi:
+        CONFIG: linux_ppc64le_amrex_precisiondpmpinompi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_amrex_precisiondpmpiopenmpi:
+        CONFIG: linux_ppc64le_amrex_precisiondpmpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_amrex_precisionspmpimpich:
+        CONFIG: linux_ppc64le_amrex_precisionspmpimpich
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_amrex_precisionspmpinompi:
+        CONFIG: linux_ppc64le_amrex_precisionspmpinompi
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_amrex_precisionspmpiopenmpi:
+        CONFIG: linux_ppc64le_amrex_precisionspmpiopenmpi
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,23 +8,41 @@ jobs:
     vmImage: macOS-13
   strategy:
     matrix:
-      osx_64_mpimpich:
-        CONFIG: osx_64_mpimpich
+      osx_64_amrex_precisiondpmpimpich:
+        CONFIG: osx_64_amrex_precisiondpmpimpich
         UPLOAD_PACKAGES: 'True'
-      osx_64_mpinompi:
-        CONFIG: osx_64_mpinompi
+      osx_64_amrex_precisiondpmpinompi:
+        CONFIG: osx_64_amrex_precisiondpmpinompi
         UPLOAD_PACKAGES: 'True'
-      osx_64_mpiopenmpi:
-        CONFIG: osx_64_mpiopenmpi
+      osx_64_amrex_precisiondpmpiopenmpi:
+        CONFIG: osx_64_amrex_precisiondpmpiopenmpi
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_mpimpich:
-        CONFIG: osx_arm64_mpimpich
+      osx_64_amrex_precisionspmpimpich:
+        CONFIG: osx_64_amrex_precisionspmpimpich
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_mpinompi:
-        CONFIG: osx_arm64_mpinompi
+      osx_64_amrex_precisionspmpinompi:
+        CONFIG: osx_64_amrex_precisionspmpinompi
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_mpiopenmpi:
-        CONFIG: osx_arm64_mpiopenmpi
+      osx_64_amrex_precisionspmpiopenmpi:
+        CONFIG: osx_64_amrex_precisionspmpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_amrex_precisiondpmpimpich:
+        CONFIG: osx_arm64_amrex_precisiondpmpimpich
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_amrex_precisiondpmpinompi:
+        CONFIG: osx_arm64_amrex_precisiondpmpinompi
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_amrex_precisiondpmpiopenmpi:
+        CONFIG: osx_arm64_amrex_precisiondpmpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_amrex_precisionspmpimpich:
+        CONFIG: osx_arm64_amrex_precisionspmpimpich
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_amrex_precisionspmpinompi:
+        CONFIG: osx_arm64_amrex_precisionspmpinompi
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_amrex_precisionspmpiopenmpi:
+        CONFIG: osx_arm64_amrex_precisionspmpiopenmpi
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,8 +8,11 @@ jobs:
     vmImage: windows-2022
   strategy:
     matrix:
-      win_64_:
-        CONFIG: win_64_
+      win_64_amrex_precisiondp:
+        CONFIG: win_64_amrex_precisiondp
+        UPLOAD_PACKAGES: 'True'
+      win_64_amrex_precisionsp:
+        CONFIG: win_64_amrex_precisionsp
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_amrex_precisiondpmpimpich.yaml
+++ b/.ci_support/linux_64_amrex_precisiondpmpimpich.yaml
@@ -1,0 +1,35 @@
+amrex_precision:
+- dp
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fftw:
+- '3'
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_64_amrex_precisiondpmpinompi.yaml
+++ b/.ci_support/linux_64_amrex_precisiondpmpinompi.yaml
@@ -1,3 +1,5 @@
+amrex_precision:
+- dp
 c_compiler:
 - gcc
 c_compiler_version:
@@ -21,7 +23,7 @@ docker_image:
 fftw:
 - '3'
 mpi:
-- mpich
+- nompi
 mpich:
 - '4'
 openmpi:

--- a/.ci_support/linux_64_amrex_precisiondpmpiopenmpi.yaml
+++ b/.ci_support/linux_64_amrex_precisiondpmpiopenmpi.yaml
@@ -1,29 +1,27 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+amrex_precision:
+- dp
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '19'
+- '14'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fftw:
 - '3'
-llvm_openmp:
-- '19'
-macos_machine:
-- x86_64-apple-darwin13.4.0
 mpi:
 - openmpi
 mpich:
@@ -31,7 +29,7 @@ mpich:
 openmpi:
 - '5'
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_amrex_precisionspmpimpich.yaml
+++ b/.ci_support/linux_64_amrex_precisionspmpimpich.yaml
@@ -1,3 +1,5 @@
+amrex_precision:
+- sp
 c_compiler:
 - gcc
 c_compiler_version:
@@ -21,7 +23,7 @@ docker_image:
 fftw:
 - '3'
 mpi:
-- openmpi
+- mpich
 mpich:
 - '4'
 openmpi:

--- a/.ci_support/linux_64_amrex_precisionspmpinompi.yaml
+++ b/.ci_support/linux_64_amrex_precisionspmpinompi.yaml
@@ -1,3 +1,5 @@
+amrex_precision:
+- sp
 c_compiler:
 - gcc
 c_compiler_version:
@@ -27,7 +29,7 @@ mpich:
 openmpi:
 - '5'
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_amrex_precisionspmpiopenmpi.yaml
+++ b/.ci_support/linux_64_amrex_precisionspmpiopenmpi.yaml
@@ -1,0 +1,35 @@
+amrex_precision:
+- sp
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fftw:
+- '3'
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_amrex_precisiondpmpimpich.yaml
+++ b/.ci_support/linux_aarch64_amrex_precisiondpmpimpich.yaml
@@ -1,37 +1,35 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+amrex_precision:
+- dp
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '19'
+- '14'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fftw:
 - '3'
-llvm_openmp:
-- '19'
-macos_machine:
-- arm64-apple-darwin20.0.0
 mpi:
-- nompi
+- mpich
 mpich:
 - '4'
 openmpi:
 - '5'
 target_platform:
-- osx-arm64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_amrex_precisiondpmpinompi.yaml
+++ b/.ci_support/linux_aarch64_amrex_precisiondpmpinompi.yaml
@@ -1,0 +1,35 @@
+amrex_precision:
+- dp
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fftw:
+- '3'
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_amrex_precisiondpmpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_amrex_precisiondpmpiopenmpi.yaml
@@ -1,3 +1,5 @@
+amrex_precision:
+- dp
 c_compiler:
 - gcc
 c_compiler_version:
@@ -21,7 +23,7 @@ docker_image:
 fftw:
 - '3'
 mpi:
-- mpich
+- openmpi
 mpich:
 - '4'
 openmpi:

--- a/.ci_support/linux_aarch64_amrex_precisionspmpimpich.yaml
+++ b/.ci_support/linux_aarch64_amrex_precisionspmpimpich.yaml
@@ -1,37 +1,35 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+amrex_precision:
+- sp
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '19'
+- '14'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fftw:
 - '3'
-llvm_openmp:
-- '19'
-macos_machine:
-- arm64-apple-darwin20.0.0
 mpi:
-- openmpi
+- mpich
 mpich:
 - '4'
 openmpi:
 - '5'
 target_platform:
-- osx-arm64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_amrex_precisionspmpinompi.yaml
+++ b/.ci_support/linux_aarch64_amrex_precisionspmpinompi.yaml
@@ -1,0 +1,35 @@
+amrex_precision:
+- sp
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fftw:
+- '3'
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_amrex_precisionspmpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_amrex_precisionspmpiopenmpi.yaml
@@ -1,0 +1,35 @@
+amrex_precision:
+- sp
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fftw:
+- '3'
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_amrex_precisiondpmpimpich.yaml
+++ b/.ci_support/linux_ppc64le_amrex_precisiondpmpimpich.yaml
@@ -1,0 +1,35 @@
+amrex_precision:
+- dp
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fftw:
+- '3'
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_amrex_precisiondpmpinompi.yaml
+++ b/.ci_support/linux_ppc64le_amrex_precisiondpmpinompi.yaml
@@ -1,3 +1,5 @@
+amrex_precision:
+- dp
 c_compiler:
 - gcc
 c_compiler_version:
@@ -21,7 +23,7 @@ docker_image:
 fftw:
 - '3'
 mpi:
-- mpich
+- nompi
 mpich:
 - '4'
 openmpi:

--- a/.ci_support/linux_ppc64le_amrex_precisiondpmpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_amrex_precisiondpmpiopenmpi.yaml
@@ -1,37 +1,35 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+amrex_precision:
+- dp
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '19'
+- '14'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '19'
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fftw:
 - '3'
-llvm_openmp:
-- '19'
-macos_machine:
-- arm64-apple-darwin20.0.0
 mpi:
-- mpich
+- openmpi
 mpich:
 - '4'
 openmpi:
 - '5'
 target_platform:
-- osx-arm64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_amrex_precisionspmpimpich.yaml
+++ b/.ci_support/linux_ppc64le_amrex_precisionspmpimpich.yaml
@@ -1,3 +1,5 @@
+amrex_precision:
+- sp
 c_compiler:
 - gcc
 c_compiler_version:
@@ -21,7 +23,7 @@ docker_image:
 fftw:
 - '3'
 mpi:
-- nompi
+- mpich
 mpich:
 - '4'
 openmpi:

--- a/.ci_support/linux_ppc64le_amrex_precisionspmpinompi.yaml
+++ b/.ci_support/linux_ppc64le_amrex_precisionspmpinompi.yaml
@@ -1,0 +1,35 @@
+amrex_precision:
+- sp
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fftw:
+- '3'
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_amrex_precisionspmpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_amrex_precisionspmpiopenmpi.yaml
@@ -1,0 +1,35 @@
+amrex_precision:
+- sp
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+fftw:
+- '3'
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_amrex_precisiondpmpimpich.yaml
+++ b/.ci_support/osx_64_amrex_precisiondpmpimpich.yaml
@@ -1,33 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+amrex_precision:
+- dp
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '14'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 fftw:
 - '3'
+llvm_openmp:
+- '19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 mpi:
-- openmpi
+- mpich
 mpich:
 - '4'
 openmpi:
 - '5'
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_amrex_precisiondpmpinompi.yaml
+++ b/.ci_support/osx_64_amrex_precisiondpmpinompi.yaml
@@ -1,25 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+amrex_precision:
+- dp
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '14'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 fftw:
 - '3'
+llvm_openmp:
+- '19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 mpi:
 - nompi
 mpich:
@@ -27,7 +33,7 @@ mpich:
 openmpi:
 - '5'
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_amrex_precisiondpmpiopenmpi.yaml
+++ b/.ci_support/osx_64_amrex_precisiondpmpiopenmpi.yaml
@@ -2,6 +2,8 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
+amrex_precision:
+- dp
 c_compiler:
 - clang
 c_compiler_version:
@@ -25,7 +27,7 @@ llvm_openmp:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:
-- nompi
+- openmpi
 mpich:
 - '4'
 openmpi:

--- a/.ci_support/osx_64_amrex_precisionspmpimpich.yaml
+++ b/.ci_support/osx_64_amrex_precisionspmpimpich.yaml
@@ -1,33 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+amrex_precision:
+- sp
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '14'
+- '19'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '14'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '19'
 fftw:
 - '3'
+llvm_openmp:
+- '19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 mpi:
-- openmpi
+- mpich
 mpich:
 - '4'
 openmpi:
 - '5'
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_amrex_precisionspmpinompi.yaml
+++ b/.ci_support/osx_64_amrex_precisionspmpinompi.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+amrex_precision:
+- sp
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+fftw:
+- '3'
+llvm_openmp:
+- '19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_64_amrex_precisionspmpiopenmpi.yaml
+++ b/.ci_support/osx_64_amrex_precisionspmpiopenmpi.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+amrex_precision:
+- sp
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+fftw:
+- '3'
+llvm_openmp:
+- '19'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_amrex_precisiondpmpimpich.yaml
+++ b/.ci_support/osx_arm64_amrex_precisiondpmpimpich.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+amrex_precision:
+- dp
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+fftw:
+- '3'
+llvm_openmp:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_amrex_precisiondpmpinompi.yaml
+++ b/.ci_support/osx_arm64_amrex_precisiondpmpinompi.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+amrex_precision:
+- dp
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+fftw:
+- '3'
+llvm_openmp:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_amrex_precisiondpmpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_amrex_precisiondpmpiopenmpi.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+amrex_precision:
+- dp
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+fftw:
+- '3'
+llvm_openmp:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_amrex_precisionspmpimpich.yaml
+++ b/.ci_support/osx_arm64_amrex_precisionspmpimpich.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+amrex_precision:
+- sp
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+fftw:
+- '3'
+llvm_openmp:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- mpich
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_amrex_precisionspmpinompi.yaml
+++ b/.ci_support/osx_arm64_amrex_precisionspmpinompi.yaml
@@ -1,7 +1,9 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
+amrex_precision:
+- sp
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.13'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -23,15 +25,15 @@ fftw:
 llvm_openmp:
 - '19'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 mpi:
-- mpich
+- nompi
 mpich:
 - '4'
 openmpi:
 - '5'
 target_platform:
-- osx-64
+- osx-arm64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_arm64_amrex_precisionspmpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_amrex_precisionspmpiopenmpi.yaml
@@ -1,0 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+amrex_precision:
+- sp
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+fftw:
+- '3'
+llvm_openmp:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi:
+- openmpi
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/win_64_amrex_precisiondp.yaml
+++ b/.ci_support/win_64_amrex_precisiondp.yaml
@@ -1,0 +1,22 @@
+amrex_precision:
+- dp
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2022
+fftw:
+- '3'
+mpi:
+- nompi
+mpich:
+- '4'
+openmpi:
+- '5'
+target_platform:
+- win-64

--- a/.ci_support/win_64_amrex_precisionsp.yaml
+++ b/.ci_support/win_64_amrex_precisionsp.yaml
@@ -1,3 +1,5 @@
+amrex_precision:
+- sp
 c_compiler:
 - vs2022
 c_stdlib:

--- a/README.md
+++ b/README.md
@@ -35,115 +35,227 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_mpimpich</td>
+              <td>linux_64_amrex_precisiondpmpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_amrex_precisiondpmpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_mpinompi</td>
+              <td>linux_64_amrex_precisiondpmpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpinompi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_amrex_precisiondpmpinompi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_mpiopenmpi</td>
+              <td>linux_64_amrex_precisiondpmpiopenmpi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_amrex_precisiondpmpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_mpimpich</td>
+              <td>linux_64_amrex_precisionspmpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_amrex_precisionspmpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_mpinompi</td>
+              <td>linux_64_amrex_precisionspmpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpinompi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_amrex_precisionspmpinompi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_mpiopenmpi</td>
+              <td>linux_64_amrex_precisionspmpiopenmpi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_amrex_precisionspmpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_mpimpich</td>
+              <td>linux_aarch64_amrex_precisiondpmpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_amrex_precisiondpmpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_mpinompi</td>
+              <td>linux_aarch64_amrex_precisiondpmpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_mpinompi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_amrex_precisiondpmpinompi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_mpiopenmpi</td>
+              <td>linux_aarch64_amrex_precisiondpmpiopenmpi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_amrex_precisiondpmpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_mpimpich</td>
+              <td>linux_aarch64_amrex_precisionspmpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_amrex_precisionspmpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_mpinompi</td>
+              <td>linux_aarch64_amrex_precisionspmpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpinompi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_amrex_precisionspmpinompi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_mpiopenmpi</td>
+              <td>linux_aarch64_amrex_precisionspmpiopenmpi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_amrex_precisionspmpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_mpimpich</td>
+              <td>linux_ppc64le_amrex_precisiondpmpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpimpich" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_amrex_precisiondpmpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_mpinompi</td>
+              <td>linux_ppc64le_amrex_precisiondpmpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpinompi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_amrex_precisiondpmpinompi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_mpiopenmpi</td>
+              <td>linux_ppc64le_amrex_precisiondpmpiopenmpi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_mpiopenmpi" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_amrex_precisiondpmpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64</td>
+              <td>linux_ppc64le_amrex_precisionspmpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_amrex_precisionspmpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_amrex_precisionspmpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_amrex_precisionspmpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_amrex_precisionspmpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_amrex_precisionspmpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_amrex_precisiondpmpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_amrex_precisiondpmpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_amrex_precisiondpmpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_amrex_precisiondpmpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_amrex_precisiondpmpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_amrex_precisiondpmpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_amrex_precisionspmpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_amrex_precisionspmpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_amrex_precisionspmpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_amrex_precisionspmpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_amrex_precisionspmpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_amrex_precisionspmpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_amrex_precisiondpmpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_amrex_precisiondpmpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_amrex_precisiondpmpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_amrex_precisiondpmpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_amrex_precisiondpmpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_amrex_precisiondpmpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_amrex_precisionspmpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_amrex_precisionspmpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_amrex_precisionspmpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_amrex_precisionspmpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_amrex_precisionspmpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_amrex_precisionspmpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_amrex_precisiondp</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=win&configuration=win%20win_64_amrex_precisiondp" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_amrex_precisionsp</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=20581&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/amrex-feedstock?branchName=main&jobName=win&configuration=win%20win_64_amrex_precisionsp" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -1,5 +1,11 @@
 @echo on
 
+if "%amrex_precision%" == "dp" (
+    set "PRECISION=DOUBLE"
+) else (
+    set "PRECISION=SINGLE"
+)
+
 :: configure
 cmake ^
     -S %SRC_DIR% -B build           ^
@@ -23,7 +29,9 @@ cmake ^
     -DAMReX_MPI_THREAD_MULTIPLE=OFF ^
     -DAMReX_OMP=ON                  ^
     -DAMReX_PARTICLES=ON            ^
+    -DAMReX_PARTICLES_PRECISION="%PRECISION%" ^
     -DAMReX_PLOTFILE_TOOLS=OFF      ^
+    -DAMReX_PRECISION="%PRECISION%" ^
     -DAMReX_PROBINIT=OFF            ^
     -DAMReX_PIC=ON                  ^
     -DAMReX_SPACEDIM="1;2;3"        ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,6 +16,12 @@ if [[ ${mpi} == "nompi" ]]; then
 else
     export USE_MPI=ON
 fi
+# Precision variants
+if [[ ${amrex_precision} == "dp" ]]; then
+    export PRECISION="DOUBLE"
+else
+    export PRECISION="SINGLE"
+fi
 #   see https://github.com/conda-forge/hdf5-feedstock/blob/master/recipe/mpiexec.sh
 if [[ "$mpi" == "mpich" ]]; then
     export HYDRA_LAUNCHER=fork
@@ -58,7 +64,9 @@ cmake \
     -DAMReX_MPI_THREAD_MULTIPLE=OFF   \
     -DAMReX_OMP=ON                    \
     -DAMReX_PARTICLES=ON              \
+    -DAMReX_PARTICLES_PRECISION=${PRECISION} \
     -DAMReX_PLOTFILE_TOOLS=OFF        \
+    -DAMReX_PRECISION=${PRECISION}    \
     -DAMReX_PROBINIT=OFF              \
     -DAMReX_PIC=ON                    \
     -DAMReX_SPACEDIM="1;2;3"          \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,3 +2,7 @@ mpi:
   - nompi
   - mpich  # [unix]
   - openmpi  # [unix]
+
+amrex_precision:
+  - dp
+  - sp

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -64,7 +64,7 @@ requirements:
       then: libcxx
   run_exports:
     # strict runtime dependency on build-time MPI flavor and DP/SP variant
-    - ${{ name }} * ${{ mpi_prefix }}_* ${{ amrex_precision }}_*
+    - ${{ name }} * ${{ mpi_prefix }}_${{ amrex_precision }}_*
     # Releases are not (yet) compatible:
     # There is no ABI compatibility check or guarantee between AMReX releases.
     - amrex ==${{ version }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,8 +5,7 @@ context:
   # prioritize nompi variant via build number
   name: amrex
   version: "25.07"
-  build: 2
-  mpi: ${{ mpi or "nompi" }}  # is this still needed?
+  build: 3
   mpi_prefix: ${{ "nompi" if mpi == "nompi" else "mpi_" + mpi }}
 
 package:
@@ -23,8 +22,8 @@ build:
   # dependencies:
   # `pkg * mpi_mpich_*` for mpich
   # `pkg * mpi_*` for any mpi
-  number: ${{ build | int + 100 if mpi == "nompi" else build }}
-  string: ${{ mpi_prefix }}_h${{ hash }}_${{ build | int + 100 if mpi == "nompi" else build }}
+  number: ${{ build | int + 100 if mpi == "nompi" and amrex_precision == "dp" else build }}
+  string: ${{ mpi_prefix }}_${{ amrex_precision }}_h${{ hash }}_${{ build | int + 100 if mpi == "nompi" else build }}
 
 requirements:
   build:
@@ -55,6 +54,7 @@ requirements:
     - if: "mpi != 'nompi'"
       then: ${{ mpi }}
     - fftw
+    - vir-simd
   run:
     - if: "mpi != 'nompi'"
       then:
@@ -62,8 +62,8 @@ requirements:
     - if: osx
       then: libcxx
   run_exports:
-    # strict runtime dependency on build-time MPI flavor
-    - ${{ name }} * ${{ mpi_prefix }}_*
+    # strict runtime dependency on build-time MPI flavor and DP/SP variant
+    - ${{ name }} * ${{ mpi_prefix }}_* ${{ amrex_precision }}_*
     # Releases are not (yet) compatible:
     # There is no ABI compatibility check or guarantee between AMReX releases.
     - amrex ==${{ version }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -6,6 +6,7 @@ context:
   name: amrex
   version: "25.07"
   build: 3
+  mpi: ${{ mpi or "nompi" }} # is this still needed?
   mpi_prefix: ${{ "nompi" if mpi == "nompi" else "mpi_" + mpi }}
 
 package:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -6,7 +6,7 @@ context:
   name: amrex
   version: "25.07"
   build: 3
-  mpi: ${{ mpi or "nompi" }} # is this still needed?
+  mpi: ${{ mpi or "nompi" }}  # is this still needed?
   mpi_prefix: ${{ "nompi" if mpi == "nompi" else "mpi_" + mpi }}
 
 package:


### PR DESCRIPTION
Add single precision build variants.

In a following version release, we should declutter this from the build string and instead create either [explicit package variants](https://rattler.build/latest/reference/recipe_file/#outputs-section) ([examples](https://github.com/search?q=org%3Aconda-forge+outputs%3A+path%3A**%2Frecipe.yaml&type=code)):
- `amrex-dp`
- `amrex-mpich-dp`
- `amrex-openmpi-dp`
- `amrex-sp`
- `amrex-mpich-sp`
- `amrex-openmpi-sp`

packages, or even better, do the same approach as we do for `-DAMReX_SPACEDIM="1;2;3"` and allow multiple values for `-DAMReX_PRECISION="SINGLE;DOUBLE"` that we encode in the libraries we build, so we can deploy them together and select at runtime (e.g., import of a Python module, etc.).
To simplify, we probably should assume field & particle precision are the same for now, otherwise we 4x our builds (now we 2x them).

That way, we could still use package outputs with distinct names, but luckily only for MPI:
- `amrex`
- `amrex-mpich`
- `amrex-openmpi`

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
