### PR TITLE
Fix: String w/ +100 for nompi AND dp

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,7 +5,7 @@ context:
   # prioritize nompi variant via build number
   name: amrex
   version: "25.08"
-  build: 4
+  build: 5
   mpi: ${{ mpi or "nompi" }}  # is this still needed?
   mpi_prefix: ${{ "nompi" if mpi == "nompi" else "mpi_" + mpi }}
 
@@ -27,7 +27,7 @@ build:
   # `pkg * mpi_mpich_*` for mpich
   # `pkg * mpi_*` for any mpi
   number: ${{ build | int + 100 if mpi == "nompi" and amrex_precision == "dp" else build }}
-  string: ${{ mpi_prefix }}_${{ amrex_precision }}_h${{ hash }}_${{ build | int + 100 if mpi == "nompi" else build }}
+  string: ${{ mpi_prefix }}_${{ amrex_precision }}_h${{ hash }}_${{ build | int + 100 if mpi == "nompi" and amrex_precision == "dp" else build }}
 
 requirements:
   build:


### PR DESCRIPTION
Only bump the double precision variant in the build number of the string.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
