### PR TITLE
Patch amrex-26.04 to fix incorrect release number in CHANGES.md

### DIFF
--- a/recipe/patches/amrex-26.04-changelog.patch
+++ b/recipe/patches/amrex-26.04-changelog.patch
@@ -1,0 +1,10 @@
+diff --git a/CHANGES.md b/CHANGES.md
+index 66a1eaaa0d..df33b8d2da 100644
+--- a/CHANGES.md
++++ b/CHANGES.md
+@@ -1,4 +1,4 @@
+-# 26.03
++# 26.04
+ 
+  ## Highlights:
+ 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,7 +5,7 @@ context:
   # prioritize nompi variant via build number
   name: amrex
   version: "26.04"
-  build: 0
+  build: 1
   mpi: ${{ mpi or "nompi" }}  # is this still needed?
   mpi_prefix: ${{ "nompi" if mpi == "nompi" else "mpi_" + mpi }}
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,6 +16,8 @@ package:
 source:
   url: https://github.com/AMReX-Codes/amrex/archive/refs/tags/${{ version }}.tar.gz
   sha256: 6774449027793ae583036150ee17d929c88cdc04fee136da8de201cbe78c4c03
+  patches:
+    - patches/amrex-26.04-changelog.patch
 
 build:
   # add build string so packages can depend on


### PR DESCRIPTION

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

Patch amrex-26.04 to fix incorrect release number in CHANGES.md
